### PR TITLE
Add Publications section with NDSS 2025 paper

### DIFF
--- a/publications.md
+++ b/publications.md
@@ -1,0 +1,10 @@
+---
+title: Publications
+layout: default
+nav_order: 4
+---
+
+For detailed information on Git repository security and how gittuf is designed,
+see the following papers:
+
+- [Rethinking Trust in Forge-Based Git Security](https://ssl.engineering.nyu.edu/papers/yelgundhalli_gittuf_ndss_2025.pdf)


### PR DESCRIPTION
This PR adds a publications section to the website, starting with the NDSS 2025 paper on gittuf.