### PR TITLE
Fix rendering of gittuf citation

### DIFF
--- a/index.md
+++ b/index.md
@@ -64,6 +64,7 @@ gittuf is developed by a combination of academic and industry security
 researchers, and has been [peer-reviewed]. To cite gittuf, use:
 
 ```
+{% raw %}
 @inproceedings{yelgundhalli2025,
     author = {Aditya Sirish A Yelgundhalli and Patrick Zielinski and Reza Curtmola and Justin Cappos},
     title = {{Rethinking Trust in Forge-Based Git Security}},
@@ -74,6 +75,7 @@ researchers, and has been [peer-reviewed]. To cite gittuf, use:
     url = {https://www.ndss-symposium.org/ndss-paper/rethinking-trust-in-forge-based-git-security/},
     publisher = {{Internet Society}},
 }
+{% endraw %}
 ```
 
 [Open Source Security Foundation (OpenSSF)]: https://openssf.org/


### PR DESCRIPTION
The citation for gittuf doesn't render properly, and this looks to impact copying it as well. I think this is due to the double braces, but unsure if this breaks the citation when actually imported into BibTeX...